### PR TITLE
Fix errors in Python learning content

### DIFF
--- a/programming/python/arrays.py
+++ b/programming/python/arrays.py
@@ -5,7 +5,7 @@ print(f"We have an office array: {offices}")
 print("\n")
 
 print("Accessing array item 0")
-x = offices
+x = offices[0]
 print(f"Found {x}")
 print("\n")
 

--- a/programming/python/functions.py
+++ b/programming/python/functions.py
@@ -2,7 +2,7 @@
 
 def file_check(fn):
   try:
-      example_csv = open("example.csv", "r")
+      example_csv = open(fn, "r")
       try:
           print("Found file, printing file")
           print("\n")

--- a/programming/python/operators.py
+++ b/programming/python/operators.py
@@ -60,11 +60,11 @@ modulus_and %= 3
 print(f"6 %= {modulus_and}")
 
 exponent_and = 2
-exponent_and *= 3
-print(f"2 *= {exponent_and}")
+exponent_and **= 3
+print(f"2 **= {exponent_and}")
 
 y = 7
 floor_division = 78125.0
 floor_division//=y
-print(f"7 //= {floor_division}")
+print(f"78125.0 //= {floor_division}")
 

--- a/programming/python/variables.py
+++ b/programming/python/variables.py
@@ -19,8 +19,6 @@ print(office_name)
 print("\n")
 print("----------------------------------------------")
 
-print("yo")
-
 print(color.BOLD_UNDERLINE + 'Assign an integer value to a variable' + color.END)
 print("\n")
 office_sales = 7
@@ -38,7 +36,7 @@ print(f"office_score is type: {office_score_type}")
 print("\n")
 print("----------------------------------------------")
 
-print(color.BOLD_UNDERLINE + 'Assign an boolean value to a variable' + color.END)
+print(color.BOLD_UNDERLINE + 'Assign a boolean value to a variable' + color.END)
 print("\n")
 office_is_active = bool(True)
 office_is_active_type = type(office_is_active)
@@ -49,5 +47,5 @@ print("----------------------------------------------")
 """
 Interesting tidbits
 
-Python employs a concept called name mangling for private variables.abs
+Python employs a concept called name mangling for private variables.
 """


### PR DESCRIPTION
Fixed 8 issues across 4 Python learning files:

Critical errors:
- arrays.py: Fixed array access example (was assigning entire array instead of accessing first element)
- operators.py: Fixed exponentiation operator demonstration (was using *= instead of **=)

Minor errors:
- variables.py: Removed debug print statement
- variables.py: Fixed grammar error ("an boolean" -> "a boolean")
- variables.py: Fixed incomplete comment about name mangling
- operators.py: Fixed misleading floor division print statement

Code quality:
- functions.py: Fixed unused parameter (now uses fn parameter instead of hardcoded filename)

🤖 Generated with [Claude Code](https://claude.com/claude-code)